### PR TITLE
Add missing SoundIoOutStream.volume

### DIFF
--- a/soundio.nimble
+++ b/soundio.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.0"
+version       = "0.2.0"
 author        = "Ruslan Prokopchuk"
 description   = "Bindings for libsoundio, a library providing cross-platform audio input and output."
 license       = "MIT"

--- a/src/soundio.nim
+++ b/src/soundio.nim
@@ -429,6 +429,8 @@ type
     ## For JACK, this value is always equal to
     ## SoundIoDevice::software_latency_current of the device.
     software_latency*: cdouble
+    ## Core Audio and WASAPI only: current output Audio Unit volume. Float, 0.0-1.0.
+    volume*: cfloat
     ## Defaults to NULL. Put whatever you want here.
     userdata*: pointer
     ## In this callback, you call ::soundio_outstream_begin_write and


### PR DESCRIPTION
I wasn't able to get the example to run. Turns out the `SoundIoOutStream` C struct has a `float volume` member which was not included in the nim `SoundIoOutStream` type. This adds the missing member and I'm now able to run the example.

I'm on macOS. I'm using libsoundio master, but was running into the same issue with libsoundio 2.0.0.